### PR TITLE
Fix for Oni 0.2.20+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ const activate = (Oni) => {
 
         const fileErrors = errors[fileName] || []
 
-        Oni.diagnostics.setErrors("tslint-ts", args.filePath, fileErrors, "yellow")
+        Oni.diagnostics.setErrors(args.filePath, "tslint-ts", fileErrors, "yellow")
 
         if (!fileErrors || fileErrors.length === 0) {
             lastErrors[args.filePath] = null
@@ -62,13 +62,13 @@ const activate = (Oni) => {
         const errors = await executeTsLint(filePath, processArgs, currentWorkingDirectory, autoFix)
                 // Send all updated errors
         Object.keys(errors).forEach(f => {
-            Oni.diagnostics.setErrors("tslint-ts", f, errors[f], "yellow")
+            Oni.diagnostics.setErrors(f, "tslint-ts", errors[f], "yellow")
         })
 
         // Send all errors that were cleared
         Object.keys(lastErrors).forEach(f => {
             if (lastErrors[f] && !errors[f]) {
-                Oni.diagnostics.setErrors("tslint-ts", f, [], "yellow")
+                Oni.diagnostics.setErrors(f, "tslint-ts", [], "yellow")
             }
         })
 


### PR DESCRIPTION
This plugin does not work with Oni 0.3.2

Diving into the code it was the `Oni.diagnostic.setErrors` call that was incorrect, looking at the signature it appears to now be `setErrors(filePath: string, key: string, errors: types.Diagnostic[]): void`, It seems to have been changed as of [this commit](https://github.com/onivim/oni/commit/9d0ec95a231607736bcae3259ca45fe45af2c280)

Simply swapping the `key` and `filePath` appears to have fixed the issue 😄 