### PR TITLE
Ignore non-typescript files when linting individual files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,11 @@ const activate = (Oni) => {
             return
         }
 
+        // Ignore files that are not typescript files.
+        if (args.language !== "typescript") {
+            return
+        }
+
         const currentWorkingDirectory = getCurrentWorkingDirectory(args.filePath)
         const filePath = await getLintConfig(currentWorkingDirectory)
 


### PR DESCRIPTION
It seems that tslint will happily lint any file under the sun, including sass and json files 😅 

To fix this I added a simple language check when linting individual files